### PR TITLE
feat: 쿠키 기반 저장으로 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.55.0",
+    "@types/js-cookie": "^3.0.6",
+    "js-cookie": "^3.0.5",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,14 @@
 import { createClient } from "@supabase/supabase-js";
+import { cookieStorage } from "../utils/cookieUtils";
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL!;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY!;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    storage: cookieStorage,
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: true,
+  },
+});

--- a/src/utils/cookieUtils.ts
+++ b/src/utils/cookieUtils.ts
@@ -1,0 +1,60 @@
+import Cookies from 'js-cookie';
+
+export const COOKIE_NAMES = {
+  ACCESS_TOKEN: 'sb-access-token',
+  REFRESH_TOKEN: 'sb-refresh-token',
+  SESSION: 'sb-session',
+} as const;
+
+export const COOKIE_OPTIONS = {
+  secure: import.meta.env.PROD,
+  sameSite: 'lax' as const,
+  expires: 7, // 7일
+  path: '/',
+};
+
+export const cookieStorage = {
+  getItem: (key: string): string | null => {
+    return Cookies.get(key) || null;
+  },
+
+  setItem: (key: string, value: string): void => {
+    Cookies.set(key, value, COOKIE_OPTIONS);
+  },
+
+  removeItem: (key: string): void => {
+    Cookies.remove(key, { path: '/' });
+  },
+};
+
+export const setSessionCookies = (session: any) => {
+  if (session) {
+    const { access_token, refresh_token } = session;
+    
+    cookieStorage.setItem(COOKIE_NAMES.ACCESS_TOKEN, access_token);
+    cookieStorage.setItem(COOKIE_NAMES.REFRESH_TOKEN, refresh_token);
+    cookieStorage.setItem(COOKIE_NAMES.SESSION, JSON.stringify(session));
+  }
+};
+
+export const clearSessionCookies = () => {
+  cookieStorage.removeItem(COOKIE_NAMES.ACCESS_TOKEN);
+  cookieStorage.removeItem(COOKIE_NAMES.REFRESH_TOKEN);
+  cookieStorage.removeItem(COOKIE_NAMES.SESSION);
+};
+
+export const getSessionFromCookies = () => {
+  const sessionStr = cookieStorage.getItem(COOKIE_NAMES.SESSION);
+  
+  if (sessionStr) {
+    try {
+      return JSON.parse(sessionStr);
+    } catch (error) {
+      console.error('Failed to parse session from cookies:', error);
+      clearSessionCookies();
+      return null;
+    }
+  }
+  
+  return null;
+};

--- a/src/utils/nextjsCompat.ts
+++ b/src/utils/nextjsCompat.ts
@@ -1,0 +1,103 @@
+import { createServerClient } from '@supabase/supabase-js';
+import { NextRequest, NextResponse } from 'next/server';
+
+interface CookieOptions {
+  name: string;
+  value: string;
+  options: {
+    httpOnly?: boolean;
+    secure?: boolean;
+    sameSite?: 'lax' | 'strict' | 'none';
+    path?: string;
+    maxAge?: number;
+  };
+}
+
+// Next.js 미들웨어에서 사용할 Supabase 클라이언트 생성 함수
+export const createSupabaseServerClient = (request: NextRequest) => {
+  let response = NextResponse.next({
+    request: {
+      headers: request.headers,
+    },
+  });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return request.cookies.get(name)?.value;
+        },
+        set(name: string, value: string, options: any) {
+          const cookieOptions: CookieOptions = {
+            name,
+            value,
+            options: {
+              ...options,
+              secure: process.env.NODE_ENV === 'production',
+              sameSite: 'lax',
+              path: '/',
+            },
+          };
+
+          response.cookies.set(cookieOptions.name, cookieOptions.value, cookieOptions.options);
+        },
+        remove(name: string, options: any) {
+          response.cookies.set({
+            name,
+            value: '',
+            ...options,
+            maxAge: 0,
+          });
+        },
+      },
+    }
+  );
+
+  return { supabase, response };
+};
+
+// Next.js API 라우트에서 사용할 함수
+export const getSessionFromServerRequest = async (request: Request) => {
+  const cookies = request.headers.get('cookie');
+  
+  if (!cookies) return null;
+
+  // 쿠키에서 세션 정보 추출
+  const sessionCookie = cookies
+    .split(';')
+    .find(c => c.trim().startsWith('sb-session='));
+
+  if (!sessionCookie) return null;
+
+  try {
+    const sessionValue = sessionCookie.split('=')[1];
+    return JSON.parse(decodeURIComponent(sessionValue));
+  } catch (error) {
+    console.error('Failed to parse session from server request:', error);
+    return null;
+  }
+};
+
+// Next.js 페이지에서 서버사이드에서 세션 확인
+export const getServerSideSession = async (context: any) => {
+  const { req } = context;
+  const cookies = req.headers.cookie;
+  
+  if (!cookies) return null;
+
+  const sessionCookie = cookies
+    .split(';')
+    .find((c: string) => c.trim().startsWith('sb-session='));
+
+  if (!sessionCookie) return null;
+
+  try {
+    const sessionValue = sessionCookie.split('=')[1];
+    return JSON.parse(decodeURIComponent(sessionValue));
+  } catch (error) {
+    console.error('Failed to parse session from server side:', error);
+    return null;
+  }
+};


### PR DESCRIPTION
### Task
- Supabase 인증을 쿠키 기반으로 변경하여 Next.js SSR/SSG와 완전 호환
- 기존 이메일 + 카카오 OAuth 인증 플로우 그대로 유지
- 쿠키를 통한 세션 관리로 서버사이드 인증 상태 확인 가능


### Changes
🔧 Dependencies
- js-cookie 추가: 쿠키 관리 라이브러리
- @types/js-cookie 추가: TypeScript 타입 정의

📁 New Files
- `src/utils/cookieUtils.ts` : 쿠키 저장/읽기/삭제 유틸리티 함수
- `src/utils/nextjsCompat.ts` : Next.js 서버 환경 호환성 함수

🔄 Modified Files
- `src/lib/supabase.ts` : 쿠키 기반 storage 설정 적용
- `src/contexts/AuthContext.tsx` : 쿠키 동기화 로직 추가

### Features
✅ 쿠키 기반 세션 저장 (sb-access-token, sb-refresh-token, sb-session)
✅ 페이지 새로고침 시 쿠키에서 세션 복구
✅ 로그아웃 시 쿠키 자동 정리
✅ Next.js SSR/SSG에서 서버사이드 인증 상태 확인 가능
✅ 기존 인증 플로우 완전 호환 (이메일 + 카카오)

### Next.js Migration Ready
이제 이 코드를 Next.js로 마이그레이션할 때:
- middleware.ts에서 쿠키 읽어 인증 상태 확인 가능
- API Routes에서 보호된 엔드포인트 구현 가능
- 서버 컴포넌트에서 인증 상태 접근 가능